### PR TITLE
Load various tools into the database

### DIFF
--- a/txbits/db/.gitattributes
+++ b/txbits/db/.gitattributes
@@ -1,0 +1,2 @@
+# See https://metacpan.org/pod/sqitchtutorial#Emergency
+sqitch.plan merge=union

--- a/txbits/db/db_tools/ddl_tools.sql
+++ b/txbits/db/db_tools/ddl_tools.sql
@@ -48,10 +48,17 @@ $f$;
 
 -- This is a db_tools file!
 
-
+/*
+ * This bit assumes that either session user is already a superuser, or that at
+ * least the su role already exists (and is superuser) and the current user has
+ * been granted access to su (either directly or via su_access).
+ */
 SELECT ddl_tools.role__create( 'su', 'SUPERUSER' );
 SET ROLE su;
 SELECT ddl_tools.role__create( 'su_access', 'NOINHERIT', 'su' );
+SELECT ddl_tools.exec($$GRANT su_access TO SESSION_USER;$$)
+  WHERE NOT pg_has_role(SESSION_USER,'su_access','usage')
+;
 
 -- Fix existing objects
 ALTER SCHEMA ddl_tools OWNER TO su;

--- a/txbits/db/ddl_tools.sql
+++ b/txbits/db/ddl_tools.sql
@@ -1,0 +1,1 @@
+db_tools/ddl_tools.sql

--- a/txbits/db/deploy/INIT.ddl_tools.sql
+++ b/txbits/db/deploy/INIT.ddl_tools.sql
@@ -1,0 +1,10 @@
+-- Deploy txbits:INIT.ddl_tools.sql to pg
+-- requires: 5
+
+BEGIN;
+--SET ROLE txbits__owner;
+
+\i :DB_DIR/ddl_tools.sql
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/deploy/INIT.pgtap.sql
+++ b/txbits/db/deploy/INIT.pgtap.sql
@@ -1,0 +1,12 @@
+-- Deploy txbits:INIT.pgtap to pg
+-- requires: INIT.ddl_tools
+
+BEGIN;
+SET ROLE su;
+
+CREATE SCHEMA tap;
+GRANT USAGE ON SCHEMA tap TO public;
+CREATE EXTENSION pgtap SCHEMA tap;
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/deploy/INIT.roles.sql
+++ b/txbits/db/deploy/INIT.roles.sql
@@ -6,10 +6,16 @@ SET ROLE su;
 
 -- Non-login roles
 SELECT ddl_tools.role__create( 'txbits__' || suffix )
-	FROM unnest( '{owner, read, read_pii, app, dev}'::text[] ) AS suffix
+	FROM unnest( '{owner, read, app, dev}'::text[] ) AS suffix
 ;
-GRANT txbits__read TO txbits__read_pii;
-GRANT txbits__read_pii TO txbits__app;
+
+/*
+ * NOTE: this is normally done by some functions that make it easy to create
+ * new schemas, so some of it's a bit redundant.
+ */
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO txbits__read, txbits__dev;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO txbits__app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO txbits__app;
 
 -- Login roles
 /*

--- a/txbits/db/deploy/INIT.roles.sql
+++ b/txbits/db/deploy/INIT.roles.sql
@@ -14,6 +14,10 @@ SET ROLE su;
 -- TODO: Instead of this, add the application user to txbits__app and change the OWNER to txbits__owner
 GRANT ALL ON SCHEMA public TO txbits__owner;
 
+-- Allow owner to use tools...
+GRANT USAGE ON SCHEMA ddl_tools TO txbits__owner;
+GRANT USAGE ON SCHEMA _ddl_tools TO txbits__owner;
+
 /*
  * NOTE: this is normally done by some functions that make it easy to create
  * new schemas, so some of it's a bit redundant.

--- a/txbits/db/deploy/INIT.roles.sql
+++ b/txbits/db/deploy/INIT.roles.sql
@@ -1,0 +1,23 @@
+-- Deploy txbits:INIT.roles to pg
+-- requires: INIT.ddl_tools
+
+BEGIN;
+SET ROLE su;
+
+-- Non-login roles
+SELECT ddl_tools.role__create( 'txbits__' || suffix )
+	FROM unnest( '{owner, read, read_pii, app, dev}'::text[] ) AS suffix
+;
+GRANT txbits__read TO txbits__read_pii;
+GRANT txbits__read_pii TO txbits__app;
+
+-- Login roles
+/*
+SELECT ddl_tools.role__create( 'txbits_frontend', $opt$LOGIN PASSWORD '' $opt$ );
+SELECT ddl_tools.role__create( 'txbits_portal', $opt$LOGIN PASSWORD '' $opt$ );
+GRANT txbits__app TO txbits_frontend, txbits_portal;
+*/
+
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/deploy/INIT.roles.sql
+++ b/txbits/db/deploy/INIT.roles.sql
@@ -9,6 +9,11 @@ SELECT ddl_tools.role__create( 'txbits__' || suffix )
 	FROM unnest( '{owner, read, app, dev}'::text[] ) AS suffix
 ;
 
+SET ROLE su;
+
+-- TODO: Instead of this, add the application user to txbits__app and change the OWNER to txbits__owner
+GRANT ALL ON SCHEMA public TO txbits__owner;
+
 /*
  * NOTE: this is normally done by some functions that make it easy to create
  * new schemas, so some of it's a bit redundant.

--- a/txbits/db/deploy/INIT.schemas.sql
+++ b/txbits/db/deploy/INIT.schemas.sql
@@ -1,0 +1,14 @@
+-- Deploy txbits:INIT.schemas to pg
+-- requires: INIT.roles
+
+BEGIN;
+SET ROLE su; -- Or could be database owner...
+
+-- Normally this would be handled by ddl_tools.create_schema()
+CREATE SCHEMA _public AUTHORIZATION txbits__owner; -- 'private' schema
+CREATE SCHEMA _test_public AUTHORIZATION txbits__owner; -- test schema
+CREATE SCHEMA _test__public AUTHORIZATION txbits__owner; -- test schema for _public
+
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/deploy/INIT.test_factory.sql
+++ b/txbits/db/deploy/INIT.test_factory.sql
@@ -1,0 +1,12 @@
+-- Deploy txbits:INIT.test_factory to pg
+-- requires: INIT.pgtap
+
+BEGIN;
+SET ROLE su;
+
+SET search_path = "$user", public, tap; -- Make sure pgtap is in our search path...
+CREATE EXTENSION test_factory;
+CREATE EXTENSION test_factory_pgtap;
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/functions
+++ b/txbits/db/functions
@@ -1,0 +1,1 @@
+db_tools/functions

--- a/txbits/db/rebuild
+++ b/txbits/db/rebuild
@@ -161,7 +161,7 @@ sudo easy_install pgxnclient"
 # pgxn_install depends on this
 EXTDIR=`$PGCONFIG --sharedir`/extension || die 1 "$PGCONFIG returned $?"
 
-#pgxn_install pgtap
+pgxn_install pgtap
 #pgxn_install test_factory
 
 debug_vars 9 dbname psql_opts test_data force tests PGXN_OPTS

--- a/txbits/db/rebuild
+++ b/txbits/db/rebuild
@@ -187,7 +187,7 @@ See http://sqitch.org/ for installation instructions."
 
 if [ -n "$run_test" ]; then
   # Note that PGSERVICE is already exported, so should get picked up
-  #./run_test $tests $dbname $psql_opts || exit $?
+  ./run_test $tests $dbname $psql_opts || exit $?
 
   # Don't bother if we're just going to load the test data for real down below
   if [ -z "$test_data" -a -x test_data__load ]; then

--- a/txbits/db/rebuild
+++ b/txbits/db/rebuild
@@ -162,7 +162,7 @@ sudo easy_install pgxnclient"
 EXTDIR=`$PGCONFIG --sharedir`/extension || die 1 "$PGCONFIG returned $?"
 
 pgxn_install pgtap
-#pgxn_install test_factory
+pgxn_install test_factory
 
 debug_vars 9 dbname psql_opts test_data force tests PGXN_OPTS
 

--- a/txbits/db/revert/INIT.ddl_tools.sql
+++ b/txbits/db/revert/INIT.ddl_tools.sql
@@ -1,0 +1,14 @@
+-- Revert txbits:INIT.ddl_tools.sql from pg
+
+BEGIN;
+--SET ROLE txbits__owner;
+
+SET client_min_messages = WARNING; -- squelch noise
+
+DROP SCHEMA _test_ddl_tools CASCADE;
+DROP SCHEMA _ddl_tools CASCADE;
+DROP SCHEMA ddl_tools CASCADE;
+
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/revert/INIT.pgtap.sql
+++ b/txbits/db/revert/INIT.pgtap.sql
@@ -3,7 +3,8 @@
 BEGIN;
 SET ROLE su;
 
-DROP SCHEMA tap CASCADE;
+DROP EXTENSION pgtap;
+DROP SCHEMA tap;
 COMMIT;
 
 -- vi: expandtab ts=2 sw=2

--- a/txbits/db/revert/INIT.pgtap.sql
+++ b/txbits/db/revert/INIT.pgtap.sql
@@ -1,0 +1,9 @@
+-- Revert txbits:INIT.pgtap from pg
+
+BEGIN;
+SET ROLE su;
+
+DROP SCHEMA tap CASCADE;
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/revert/INIT.roles.sql
+++ b/txbits/db/revert/INIT.roles.sql
@@ -1,0 +1,7 @@
+-- Revert txbits:INIT.roles from pg
+
+BEGIN;
+-- None, because roles are cluster-wide so dropping them can be problematic
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/revert/INIT.schemas.sql
+++ b/txbits/db/revert/INIT.schemas.sql
@@ -1,0 +1,11 @@
+-- Revert txbits:INIT.schemas from pg
+
+BEGIN;
+SET ROLE su;
+
+DROP SCHEMA _public; -- 'private' schema
+DROP SCHEMA _test_public; -- test schema
+DROP SCHEMA _test__public; -- test schema for _public
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/revert/INIT.test_factory.sql
+++ b/txbits/db/revert/INIT.test_factory.sql
@@ -1,0 +1,10 @@
+-- Revert txbits:INIT.test_factory from pg
+
+BEGIN;
+SET ROLE su;
+
+DROP EXTENSION test_factory_pgtap;
+DROP EXTENSION test_factory;
+COMMIT;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/sqitch.conf
+++ b/txbits/db/sqitch.conf
@@ -14,7 +14,7 @@
 	verify = true
 
 [deploy.variables]
-    DB_DIR = db
+    DB_DIR = .
 
 [add]
 	template_directory = template

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -7,3 +7,5 @@
 4 2017-08-18T02:58:48Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Original schema file $f
 5 2017-08-18T02:58:49Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Original schema file $f
 @initial 2017-08-20T22:22:28Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Initial conversion of schema to sqitch.
+
+INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Create ddl_tools schema

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -9,3 +9,4 @@
 @initial 2017-08-20T22:22:28Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Initial conversion of schema to sqitch.
 
 INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Create ddl_tools schema
+INIT.pgtap [INIT.ddl_tools] 2017-08-20T22:57:10Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add pgTap

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -12,3 +12,4 @@ INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.
 INIT.pgtap [INIT.ddl_tools] 2017-08-20T22:57:10Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add pgTap
 INIT.test_factory [INIT.pgtap] 2017-08-20T23:23:23Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add extension test_factory
 INIT.roles [INIT.ddl_tools] 2017-08-20T23:32:42Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add txbits roles
+@tool_and_role_setup 2017-08-20T23:38:04Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Setup of various tools and system roles

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -12,4 +12,6 @@ INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.
 INIT.pgtap [INIT.ddl_tools] 2017-08-20T22:57:10Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add pgTap
 INIT.test_factory [INIT.pgtap] 2017-08-20T23:23:23Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add extension test_factory
 INIT.roles [INIT.ddl_tools] 2017-08-20T23:32:42Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add txbits roles
+INIT.schemas [INIT.roles] 2017-08-21T00:13:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add test and private schemas for public
 @tool_and_role_setup 2017-08-20T23:38:04Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Setup of various tools and system roles
+

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -11,3 +11,4 @@
 INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Create ddl_tools schema
 INIT.pgtap [INIT.ddl_tools] 2017-08-20T22:57:10Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add pgTap
 INIT.test_factory [INIT.pgtap] 2017-08-20T23:23:23Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add extension test_factory
+INIT.roles [INIT.ddl_tools] 2017-08-20T23:32:42Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add txbits roles

--- a/txbits/db/sqitch.plan
+++ b/txbits/db/sqitch.plan
@@ -10,3 +10,4 @@
 
 INIT.ddl_tools [5] 2017-08-20T22:47:26Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Create ddl_tools schema
 INIT.pgtap [INIT.ddl_tools] 2017-08-20T22:57:10Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add pgTap
+INIT.test_factory [INIT.pgtap] 2017-08-20T23:23:23Z Jim Nasby <Jim.Nasby@ReddereDevelopment.com> # Add extension test_factory

--- a/txbits/db/verify/INIT.ddl_tools.sql
+++ b/txbits/db/verify/INIT.ddl_tools.sql
@@ -1,0 +1,9 @@
+-- Verify txbits:INIT.ddl_tools.sql on pg
+
+BEGIN;
+--SET ROLE txbits__owner;
+
+SELECT 'ddl_tools.role__create'::regproc;
+ROLLBACK;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.pgtap.sql
+++ b/txbits/db/verify/INIT.pgtap.sql
@@ -3,7 +3,7 @@
 BEGIN;
 SET ROLE su;
 
-SELECT 'tap.ok'::regproc;
+SELECT 'tap.ok(boolean)'::regprocedure;
 
 ROLLBACK;
 

--- a/txbits/db/verify/INIT.pgtap.sql
+++ b/txbits/db/verify/INIT.pgtap.sql
@@ -1,0 +1,10 @@
+-- Verify txbits:INIT.pgtap on pg
+
+BEGIN;
+SET ROLE su;
+
+SELECT 'tap.ok'::regproc;
+
+ROLLBACK;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.roles.sql
+++ b/txbits/db/verify/INIT.roles.sql
@@ -1,0 +1,10 @@
+-- Verify txbits:INIT.roles on pg
+
+BEGIN;
+
+-- Sufficient enough to verify... :)
+SET ROLE txbits__owner;
+
+ROLLBACK;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.roles.sql
+++ b/txbits/db/verify/INIT.roles.sql
@@ -1,10 +1,9 @@
 -- Verify txbits:INIT.roles on pg
 
 BEGIN;
-
--- Sufficient enough to verify... :)
 SET ROLE txbits__owner;
 
+CREATE TABLE public.test_table();
 ROLLBACK;
 
 -- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.roles.sql
+++ b/txbits/db/verify/INIT.roles.sql
@@ -4,6 +4,14 @@ BEGIN;
 SET ROLE txbits__owner;
 
 CREATE TABLE public.test_table();
+SELECT ddl_tools.test_function(
+  'bogus'
+  , $$
+BEGIN
+  NULL;
+END
+$$);
+
 ROLLBACK;
 
 -- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.schemas.sql
+++ b/txbits/db/verify/INIT.schemas.sql
@@ -1,0 +1,9 @@
+-- Verify txbits:INIT.schemas on pg
+
+BEGIN;
+SET ROLE txbits__owner;
+
+SELECT '_public'::regnamespace;
+ROLLBACK;
+
+-- vi: expandtab ts=2 sw=2

--- a/txbits/db/verify/INIT.test_factory.sql
+++ b/txbits/db/verify/INIT.test_factory.sql
@@ -1,0 +1,9 @@
+-- Verify txbits:INIT.test_factory on pg
+
+BEGIN;
+SET ROLE su;
+
+SELECT 'tf.get'::regproc;
+ROLLBACK;
+
+-- vi: expandtab ts=2 sw=2


### PR DESCRIPTION
This patch adds various pieces of tooling to the database. These are mostly for test purposes, but it also sets up a set of standard database roles.